### PR TITLE
Allow defining a table as non-opaque.

### DIFF
--- a/src/main/java/io/github/alloffabric/artis/Artis.java
+++ b/src/main/java/io/github/alloffabric/artis/Artis.java
@@ -46,7 +46,11 @@ public class Artis implements ModInitializer {
 	public static Block registerTable(ArtisTableType type, Optional<Block.Settings> settings) {
 		Identifier id = type.getId();
 		ContainerProviderRegistry.INSTANCE.registerFactory(id, (syncId, containerId, player, buf) -> new ArtisCraftingController(type, syncId, player, BlockContext.create(player.world, buf.readBlockPos())));
-		ArtisTableBlock block = Registry.register(Registry.BLOCK, id, new ArtisTableBlock(type, settings.orElse(FabricBlockSettings.copy(Blocks.CRAFTING_TABLE).build())));
+		Block.Settings blockSettings = settings.orElse(FabricBlockSettings.copy(Blocks.CRAFTING_TABLE).build());
+		if (!type.isOpaque()) {
+            blockSettings = blockSettings.nonOpaque();
+        }
+		ArtisTableBlock block = Registry.register(Registry.BLOCK, id, new ArtisTableBlock(type, blockSettings));
 		ARTIS_TABLE_BLOCKS.add(block);
 		Registry.register(Registry.ITEM, id, new ArtisTableItem(block, new Item.Settings().group(ARTIS_GROUP)));
 		Registry.register(ARTIS_TABLE_TYPES, id, type);

--- a/src/main/java/io/github/alloffabric/artis/ArtisData.java
+++ b/src/main/java/io/github/alloffabric/artis/ArtisData.java
@@ -90,10 +90,11 @@ public class ArtisData {
 			height = 9;
 		}
 		boolean genAssets = json.containsKey("generate_assets")? json.get(Boolean.class, ("generate_assets")) : false;
+        boolean opaque = json.containsKey("opaque")? json.get(Boolean.class, ("opaque")) : true;
 		if (json.containsKey("color")) {
-			return new ArtisTableType(id, width, height, genAssets, Integer.decode(json.get(String.class, "color").replace("#", "0x")));
+			return new ArtisTableType(id, width, height, genAssets, opaque, Integer.decode(json.get(String.class, "color").replace("#", "0x")));
 		}
-		return new ArtisTableType(id, width, height, genAssets);
+		return new ArtisTableType(id, width, height, genAssets, opaque);
 	}
 
 }

--- a/src/main/java/io/github/alloffabric/artis/api/ArtisTableType.java
+++ b/src/main/java/io/github/alloffabric/artis/api/ArtisTableType.java
@@ -13,22 +13,24 @@ public class ArtisTableType implements RecipeType {
 	private int height;
 	private int color = 0;
 	private boolean generateAssets;
+	private boolean opaque;
 	private boolean hasColor = false;
 	private RecipeSerializer shaped;
 	private RecipeSerializer shapeless;
 
-	public ArtisTableType(Identifier id, int width, int height, boolean makeModel, int color) {
-		this(id, width, height, makeModel);
+	public ArtisTableType(Identifier id, int width, int height, boolean makeModel, boolean opaque, int color) {
+		this(id, width, height, makeModel, opaque);
 		this.color = 0xFF000000 | color;
 		this.hasColor = true;
 	}
 
 	//TODO: block settings?
-	public ArtisTableType(Identifier id, int width, int height, boolean makeModel) {
+	public ArtisTableType(Identifier id, int width, int height, boolean makeModel, boolean opaque) {
 		this.id = id;
 		this.width = width;
 		this.height = height;
 		this.generateAssets = makeModel;
+		this.opaque = opaque;
 		Identifier shapedId = new Identifier(id.getNamespace(), id.getPath() + "_shaped");
 		Identifier shapelessId = new Identifier(id.getNamespace(), id.getPath() + "_shapeless");
 		this.shaped = Registry.register(Registry.RECIPE_SERIALIZER, shapedId, new ShapedArtisSerializer(this));
@@ -59,7 +61,11 @@ public class ArtisTableType implements RecipeType {
 		return generateAssets;
 	}
 
-	public boolean hasColor() {
+    public boolean isOpaque() {
+        return opaque;
+    }
+
+    public boolean hasColor() {
 		return hasColor;
 	}
 

--- a/src/main/java/io/github/alloffabric/artis/compat/rei/ColorableEntryWidget.java
+++ b/src/main/java/io/github/alloffabric/artis/compat/rei/ColorableEntryWidget.java
@@ -1,8 +1,3 @@
-//
-// Source code recreated from a .class file by IntelliJ IDEA
-// (powered by Fernflower decompiler)
-//
-
 package io.github.alloffabric.artis.compat.rei;
 
 import com.mojang.blaze3d.platform.GlStateManager;


### PR DESCRIPTION
This PR allows the user to define a table as non-opaque by adding `"opaque": false` to their table. This allows the user to easily prevent non-square tables from making the world able to be seen through. This is really only needed in cases where you are copying settings and the block isn't already non-opaque (such as with the crafting table). By default opaque is set to true, but the `settings` you have set may override things and make it false.

This should fix the issue found in #14.