### PR TITLE
Tons of new features and bug fixes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 	mavenCentral()
 	maven { url "http://server.bbkr.space:8081/artifactory/libs-release" }
 	maven { url "https://minecraft.curseforge.com/api/maven" }
-	maven { url "https://www.jitpack.io" }
+	maven { url "https://jitpack.io" }
 	maven { url "https://maven.swordglowsblue.com" }
 }
 
@@ -54,12 +54,12 @@ dependencies {
 	modApi "io.github.cottonmc:LibGui:1.4.0"
 	modApi "io.github.cottonmc:StaticData:1.1.2"
 	modImplementation("me.shedaniel:RoughlyEnoughItems:3.3.15") { exclude module: "ModMenu" }
-	//modApi "com.github.siphalor:nbt-crafting:1.2.5"
-	modImplementation "com.lettuce.fudge:artifice:0.5.1+1.15.1"
+	modImplementation "com.github.Siphalor:nbt-crafting:1.15-2.0-SNAPSHOT"
+	modImplementation "com.lettuce.fudge:artifice:0.6.0+1.15.2"
 
 	include "io.github.cottonmc:LibGui:1.4.0"
 	include "io.github.cottonmc:StaticData:1.1.2"
-	include "com.lettuce.fudge:artifice:0.5.1+1.15.1"
+	include "com.lettuce.fudge:artifice:0.6.0+1.15.2"
 
 }
 

--- a/src/main/java/io/github/alloffabric/artis/Artis.java
+++ b/src/main/java/io/github/alloffabric/artis/Artis.java
@@ -42,7 +42,7 @@ public class Artis implements ModInitializer {
 	public void onInitialize() {
 		ArtisData.loadData();
 		ArtisData.loadConfig();
-        ArtisEvents.init();
+		ArtisEvents.init();
 		if (FabricLoader.getInstance().isModLoaded("libcd")) {
 			ArtisTweaker.init();
 		}

--- a/src/main/java/io/github/alloffabric/artis/Artis.java
+++ b/src/main/java/io/github/alloffabric/artis/Artis.java
@@ -42,7 +42,7 @@ public class Artis implements ModInitializer {
 	public void onInitialize() {
 		ArtisData.loadData();
 		ArtisData.loadConfig();
-        ArtisEvents.init();;
+        ArtisEvents.init();
 		if (FabricLoader.getInstance().isModLoaded("libcd")) {
 			ArtisTweaker.init();
 		}

--- a/src/main/java/io/github/alloffabric/artis/ArtisClient.java
+++ b/src/main/java/io/github/alloffabric/artis/ArtisClient.java
@@ -4,6 +4,8 @@ import com.swordglowsblue.artifice.api.Artifice;
 import com.swordglowsblue.artifice.api.builder.assets.BlockStateBuilder;
 import com.swordglowsblue.artifice.api.builder.assets.ModelBuilder;
 import com.swordglowsblue.artifice.api.util.Processor;
+import io.github.alloffabric.artis.api.ArtisExistingBlockType;
+import io.github.alloffabric.artis.api.ArtisExistingItemType;
 import io.github.alloffabric.artis.api.ArtisTableType;
 import io.github.alloffabric.artis.inventory.ArtisCraftingController;
 import io.github.alloffabric.artis.inventory.ArtisCraftingScreen;
@@ -30,16 +32,18 @@ public class ArtisClient implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
 		for (ArtisTableType type : Artis.ARTIS_TABLE_TYPES) {
-			ScreenProviderRegistry.INSTANCE.registerFactory(type.getId(), controller -> new ArtisCraftingScreen((ArtisCraftingController) controller, ((ArtisCraftingController) controller).getPlayer()));
-			if (type.shouldGenerateAssets()) {
-				BLOCKSTATES.put(type.getId(), builder -> builder.variant("", variant -> variant.model(new Identifier(Artis.MODID, "block/table" + (type.hasColor()? "_overlay" : "")))));
-				ITEM_MODELS.put(type.getId(), builder -> builder.parent(new Identifier(Artis.MODID, "block/table" + (type.hasColor()? "_overlay" : ""))));
-			}
-			if (type.hasColor()) {
-				ColorProviderRegistry.BLOCK.register((state, world, pos, index) -> type.getColor(), Registry.BLOCK.get(type.getId()));
-				ColorProviderRegistry.ITEM.register((stack, index) -> type.getColor(), Registry.ITEM.get(type.getId()));
-			}
-            BlockRenderLayerMap.INSTANCE.putBlock(Registry.BLOCK.get(type.getId()), RenderLayer.getCutout());
+            ScreenProviderRegistry.INSTANCE.registerFactory(type.getId(), controller -> new ArtisCraftingScreen((ArtisCraftingController) controller, ((ArtisCraftingController) controller).getPlayer()));
+		    if (!(type instanceof ArtisExistingBlockType) && !(type instanceof ArtisExistingItemType)) {
+                if (type.shouldGenerateAssets()) {
+                    BLOCKSTATES.put(type.getId(), builder -> builder.variant("", variant -> variant.model(new Identifier(Artis.MODID, "block/table" + (type.hasColor() ? "_overlay":"")))));
+                    ITEM_MODELS.put(type.getId(), builder -> builder.parent(new Identifier(Artis.MODID, "block/table" + (type.hasColor() ? "_overlay":""))));
+                }
+                if (type.hasColor()) {
+                    ColorProviderRegistry.BLOCK.register((state, world, pos, index) -> type.getColor(), Registry.BLOCK.get(type.getId()));
+                    ColorProviderRegistry.ITEM.register((stack, index) -> type.getColor(), Registry.ITEM.get(type.getId()));
+                }
+                BlockRenderLayerMap.INSTANCE.putBlock(Registry.BLOCK.get(type.getId()), RenderLayer.getCutout());
+            }
 		}
 		Artifice.registerAssets(new Identifier(Artis.MODID, "artis_assets"), assets -> {
 			for (Identifier id : BLOCKSTATES.keySet()) {
@@ -53,8 +57,9 @@ public class ArtisClient implements ClientModInitializer {
 
 	public static Text getName(Identifier id) {
 		String key = "block." + id.getNamespace() + "." + id.getPath();
-		if (Language.getInstance().hasTranslation(key)) return new TranslatableText(key);
-		else {
+		if (Language.getInstance().hasTranslation(key)) {
+            return new TranslatableText(key);
+        } else {
 			String[] split = id.getPath().split("_");
 			StringBuilder builder = new StringBuilder();
 			for (String string : split) {

--- a/src/main/java/io/github/alloffabric/artis/ArtisData.java
+++ b/src/main/java/io/github/alloffabric/artis/ArtisData.java
@@ -4,6 +4,8 @@ import blue.endless.jankson.Jankson;
 import blue.endless.jankson.JsonElement;
 import blue.endless.jankson.JsonObject;
 import blue.endless.jankson.api.SyntaxError;
+import io.github.alloffabric.artis.api.ArtisExistingBlockType;
+import io.github.alloffabric.artis.api.ArtisExistingItemType;
 import io.github.alloffabric.artis.api.ArtisTableType;
 import io.github.cottonmc.jankson.JanksonFactory;
 import io.github.cottonmc.staticdata.StaticData;
@@ -78,23 +80,45 @@ public class ArtisData {
 
 	//TODO: more options for tables
 	static ArtisTableType getType(String key, JsonObject json) {
-		Identifier id = new Identifier(key);
-		int width = json.get(Integer.class, "width");
-		int height = json.get(Integer.class, "height");
-		if (width > 9) {
-			Artis.logger.error("[Artis] Table type named {} has too many columns, clamping it to 9", key);
-			width = 9;
-		}
-		if (height > 9) {
-			Artis.logger.error("[Artis] Table type named {} has too many rows, clamping it to 9", key);
-			height = 9;
-		}
-		boolean genAssets = json.containsKey("generate_assets")? json.get(Boolean.class, ("generate_assets")) : false;
-        boolean opaque = json.containsKey("opaque")? json.get(Boolean.class, ("opaque")) : true;
-		if (json.containsKey("color")) {
-			return new ArtisTableType(id, width, height, genAssets, opaque, Integer.decode(json.get(String.class, "color").replace("#", "0x")));
-		}
-		return new ArtisTableType(id, width, height, genAssets, opaque);
+        Identifier id = new Identifier(key);
+        String tableType = json.containsKey("type") ? json.get(String.class, "type"):"normal";
+        int width = json.get(Integer.class, "width");
+        int height = json.get(Integer.class, "height");
+        if (width > 9) {
+            Artis.logger.error("[Artis] Table type named {} has too many columns, clamping it to 9", key);
+            width = 9;
+        }
+        if (height > 9) {
+            Artis.logger.error("[Artis] Table type named {} has too many rows, clamping it to 9", key);
+            height = 9;
+        }
+        boolean catalystSlot = json.containsKey("catalyst_slot") ? json.get(Boolean.class, "catalyst_slot") : false;
+        boolean includeNormalRecipes = json.containsKey("normal_recipes") ? json.get(Boolean.class, "normal_recipes") : false;
+        boolean genAssets = json.containsKey("generate_assets") ? json.get(Boolean.class, ("generate_assets")):false;
+        boolean opaque = json.containsKey("opaque") ? json.get(Boolean.class, ("opaque")):true;
+        if (tableType.equals("existing_block")) {
+            if (Registry.BLOCK.containsId(id) || json.containsKey("bypass_check") && json.get(Boolean.class, "bypass_check")) {
+                if (json.containsKey("color")) {
+                    return new ArtisExistingBlockType(id, width, height, catalystSlot, includeNormalRecipes, genAssets, Integer.decode(json.get(String.class, "color").replace("#", "0x")));
+                }
+                return new ArtisExistingBlockType(id, width, height, catalystSlot, includeNormalRecipes, genAssets);
+            } else {
+                Artis.logger.error("[Artis] Table type named {} could not find the block specified. Are you sure it exists? If it definitely exists, try setting bypass_check to true.", key);
+            }
+        } else if (tableType.equals("existing_item")) {
+            if (Registry.ITEM.containsId(id) || json.containsKey("bypass_check") && json.get(Boolean.class, "bypass_check")) {
+                if (json.containsKey("color")) {
+                    return new ArtisExistingItemType(id, width, height, catalystSlot, includeNormalRecipes, genAssets, Integer.decode(json.get(String.class, "color").replace("#", "0x")));
+                }
+                return new ArtisExistingItemType(id, width, height, catalystSlot, includeNormalRecipes, genAssets);
+            } else {
+                Artis.logger.error("[Artis] Table type named {} could not find the item specified. Are you sure it exists? If it definitely exists, try setting bypass_check to true.", key);
+            }
+        }
+        if (json.containsKey("color")) {
+            return new ArtisTableType(id, width, height, catalystSlot, includeNormalRecipes, genAssets, opaque, Integer.decode(json.get(String.class, "color").replace("#", "0x")));
+        }
+        return new ArtisTableType(id, width, height, catalystSlot, includeNormalRecipes, genAssets, opaque);
 	}
 
 }

--- a/src/main/java/io/github/alloffabric/artis/api/ArtisExistingBlockType.java
+++ b/src/main/java/io/github/alloffabric/artis/api/ArtisExistingBlockType.java
@@ -1,0 +1,13 @@
+package io.github.alloffabric.artis.api;
+
+import net.minecraft.util.Identifier;
+
+public class ArtisExistingBlockType extends ArtisTableType {
+	public ArtisExistingBlockType(Identifier id, int width, int height, boolean catalystSlot, boolean includeNormalRecipes, boolean makeAssets) {
+		super(id, width, height, catalystSlot, includeNormalRecipes, makeAssets, true);
+	}
+
+    public ArtisExistingBlockType(Identifier id, int width, int height, boolean catalystSlot, boolean includeNormalRecipes, boolean makeAssets, int color) {
+        super(id, width, height, catalystSlot, includeNormalRecipes, makeAssets, true, color);
+    }
+}

--- a/src/main/java/io/github/alloffabric/artis/api/ArtisExistingItemType.java
+++ b/src/main/java/io/github/alloffabric/artis/api/ArtisExistingItemType.java
@@ -1,0 +1,13 @@
+package io.github.alloffabric.artis.api;
+
+import net.minecraft.util.Identifier;
+
+public class ArtisExistingItemType extends ArtisTableType {
+	public ArtisExistingItemType(Identifier id, int width, int height, boolean catalystSlot, boolean includeNormalRecipes, boolean makeAssets) {
+		super(id, width, height, catalystSlot, includeNormalRecipes, makeAssets, true);
+	}
+
+    public ArtisExistingItemType(Identifier id, int width, int height, boolean catalystSlot, boolean includeNormalRecipes, boolean makeAssets, int color) {
+        super(id, width, height, catalystSlot, includeNormalRecipes, makeAssets, true, color);
+    }
+}

--- a/src/main/java/io/github/alloffabric/artis/api/ArtisTableType.java
+++ b/src/main/java/io/github/alloffabric/artis/api/ArtisTableType.java
@@ -12,24 +12,28 @@ public class ArtisTableType implements RecipeType {
 	private int width;
 	private int height;
 	private int color = 0;
+	private boolean catalystSlot;
+	private boolean includeNormalRecipes;
 	private boolean generateAssets;
 	private boolean opaque;
 	private boolean hasColor = false;
 	private RecipeSerializer shaped;
 	private RecipeSerializer shapeless;
 
-	public ArtisTableType(Identifier id, int width, int height, boolean makeModel, boolean opaque, int color) {
-		this(id, width, height, makeModel, opaque);
+	public ArtisTableType(Identifier id, int width, int height, boolean catalystSlot, boolean includeNormalRecipes, boolean makeAssets, boolean opaque, int color) {
+		this(id, width, height, catalystSlot, includeNormalRecipes, makeAssets, opaque);
 		this.color = 0xFF000000 | color;
 		this.hasColor = true;
 	}
 
 	//TODO: block settings?
-	public ArtisTableType(Identifier id, int width, int height, boolean makeModel, boolean opaque) {
+	public ArtisTableType(Identifier id, int width, int height, boolean catalystSlot, boolean includeNormalRecipes, boolean makeAssets, boolean opaque) {
 		this.id = id;
 		this.width = width;
 		this.height = height;
-		this.generateAssets = makeModel;
+		this.catalystSlot = catalystSlot;
+		this.includeNormalRecipes = includeNormalRecipes;
+		this.generateAssets = makeAssets;
 		this.opaque = opaque;
 		Identifier shapedId = new Identifier(id.getNamespace(), id.getPath() + "_shaped");
 		Identifier shapelessId = new Identifier(id.getNamespace(), id.getPath() + "_shapeless");
@@ -57,7 +61,15 @@ public class ArtisTableType implements RecipeType {
 		return height;
 	}
 
-	public boolean shouldGenerateAssets() {
+	public boolean hasCatalystSlot() {
+	    return catalystSlot;
+    }
+
+    public boolean shouldIncludeNormalRecipes() {
+        return includeNormalRecipes;
+    }
+
+    public boolean shouldGenerateAssets() {
 		return generateAssets;
 	}
 

--- a/src/main/java/io/github/alloffabric/artis/compat/nbtcrafting/NbtCraftingUtil.java
+++ b/src/main/java/io/github/alloffabric/artis/compat/nbtcrafting/NbtCraftingUtil.java
@@ -1,5 +1,6 @@
 package io.github.alloffabric.artis.compat.nbtcrafting;
 
+import de.siphalor.nbtcrafting.util.RecipeUtil;
 import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.recipe.Ingredient;
@@ -8,8 +9,8 @@ import net.minecraft.util.DefaultedList;
 import java.util.Optional;
 
 public class NbtCraftingUtil {
-//	public static ItemStack getOutputStack(ItemStack output, DefaultedList<Ingredient> ingredients, CraftingInventory inv) {
-//		ItemStack stack = RecipeUtil.getDollarAppliedOutputStack(output, ingredients, inv);
-//		return Optional.ofNullable(stack).orElse(output).copy();
-//	}
+	public static ItemStack getOutputStack(ItemStack output, DefaultedList<Ingredient> ingredients, CraftingInventory inv) {
+		ItemStack stack = RecipeUtil.getDollarAppliedOutputStack(output, ingredients, inv);
+		return Optional.ofNullable(stack).orElse(output).copy();
+	}
 }

--- a/src/main/java/io/github/alloffabric/artis/compat/rei/ArtisDisplayVisibilityHandler.java
+++ b/src/main/java/io/github/alloffabric/artis/compat/rei/ArtisDisplayVisibilityHandler.java
@@ -1,5 +1,7 @@
 package io.github.alloffabric.artis.compat.rei;
 
+import io.github.alloffabric.artis.Artis;
+import io.github.alloffabric.artis.api.ArtisTableType;
 import io.github.alloffabric.artis.recipe.ShapedArtisRecipe;
 import io.github.alloffabric.artis.recipe.ShapelessArtisRecipe;
 import me.shedaniel.rei.api.DisplayVisibilityHandler;
@@ -8,6 +10,7 @@ import me.shedaniel.rei.api.RecipeDisplay;
 import me.shedaniel.rei.api.RecipeHelper;
 import net.minecraft.recipe.Recipe;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.Identifier;
 
 public class ArtisDisplayVisibilityHandler implements DisplayVisibilityHandler {
     @Override
@@ -15,7 +18,7 @@ public class ArtisDisplayVisibilityHandler implements DisplayVisibilityHandler {
         if (!(recipeCategory instanceof ArtisCategory) && recipeDisplay.getRecipeLocation().isPresent() && RecipeHelper.getInstance().getRecipeManager().get(recipeDisplay.getRecipeLocation().get()).isPresent()) {
             Recipe recipe = RecipeHelper.getInstance().getRecipeManager().get(recipeDisplay.getRecipeLocation().get()).get();
 
-            if (recipe instanceof ShapedArtisRecipe || recipe instanceof ShapelessArtisRecipe) {
+            if (recipe.getType() instanceof ArtisTableType) {
                 return ActionResult.FAIL;
             }
         }

--- a/src/main/java/io/github/alloffabric/artis/compat/rei/ArtisREIPlugin.java
+++ b/src/main/java/io/github/alloffabric/artis/compat/rei/ArtisREIPlugin.java
@@ -1,16 +1,22 @@
 package io.github.alloffabric.artis.compat.rei;
 
 import io.github.alloffabric.artis.Artis;
+import io.github.alloffabric.artis.api.ArtisExistingBlockType;
+import io.github.alloffabric.artis.api.ArtisExistingItemType;
 import io.github.alloffabric.artis.api.ArtisTableType;
 import io.github.alloffabric.artis.block.ArtisTableBlock;
 import me.shedaniel.rei.api.EntryStack;
 import me.shedaniel.rei.api.RecipeHelper;
 import me.shedaniel.rei.api.plugins.REIPluginV0;
+import me.shedaniel.rei.plugin.autocrafting.DefaultCategoryHandler;
 import net.fabricmc.loader.api.SemanticVersion;
 import net.fabricmc.loader.util.version.VersionParsingException;
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemConvertible;
 import net.minecraft.recipe.Recipe;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
 
 import java.util.*;
 import java.util.function.Predicate;
@@ -25,7 +31,6 @@ public class ArtisREIPlugin implements REIPluginV0 {
             iconMap.put(block.getType(), block);
         }
     }
-
 
     @Override
     public Identifier getPluginIdentifier() {
@@ -62,6 +67,24 @@ public class ArtisREIPlugin implements REIPluginV0 {
 
         for (ArtisTableBlock block : Artis.ARTIS_TABLE_BLOCKS) {
             recipeHelper.registerWorkingStations(block.getType().getId(), EntryStack.create(block.asItem()));
+        }
+
+        for (ArtisTableType type : Artis.ARTIS_TABLE_TYPES) {
+            if (type instanceof ArtisExistingBlockType) {
+                Block block = Registry.BLOCK.get(type.getId());
+                recipeHelper.registerWorkingStations(type.getId(), EntryStack.create(block.asItem()));
+
+                if (type.shouldIncludeNormalRecipes()) {
+                    recipeHelper.registerWorkingStations(new Identifier("minecraft", "plugins/crafting"), EntryStack.create(block.asItem()));
+                }
+            } else if (type instanceof ArtisExistingItemType) {
+                Item item = Registry.ITEM.get(type.getId());
+                recipeHelper.registerWorkingStations(type.getId(), EntryStack.create(item));
+
+                if (type.shouldIncludeNormalRecipes()) {
+                    recipeHelper.registerWorkingStations(new Identifier("minecraft", "plugins/crafting"), EntryStack.create(item));
+                }
+            }
         }
 	}
 }

--- a/src/main/java/io/github/alloffabric/artis/compat/rei/ArtisServerContainerPlugin.java
+++ b/src/main/java/io/github/alloffabric/artis/compat/rei/ArtisServerContainerPlugin.java
@@ -1,8 +1,10 @@
 package io.github.alloffabric.artis.compat.rei;
 
 import io.github.alloffabric.artis.Artis;
+import io.github.alloffabric.artis.api.ArtisExistingBlockType;
 import io.github.alloffabric.artis.api.ArtisTableType;
 import io.github.alloffabric.artis.inventory.ArtisCraftingController;
+import io.github.alloffabric.artis.inventory.ArtisNormalCraftingController;
 import me.shedaniel.rei.plugin.containers.CraftingContainerInfoWrapper;
 import me.shedaniel.rei.server.ContainerInfoHandler;
 import net.minecraft.container.*;
@@ -14,5 +16,7 @@ public class ArtisServerContainerPlugin implements Runnable {
         for (ArtisTableType type : Artis.ARTIS_TABLE_TYPES) {
             ContainerInfoHandler.registerContainerInfo(type.getId(), CraftingContainerInfoWrapper.create(ArtisCraftingController.class));
         }
+
+        ContainerInfoHandler.registerContainerInfo(new Identifier("minecraft", "plugins/crafting"), CraftingContainerInfoWrapper.create(ArtisNormalCraftingController.class));
     }
 }

--- a/src/main/java/io/github/alloffabric/artis/event/ArtisEvents.java
+++ b/src/main/java/io/github/alloffabric/artis/event/ArtisEvents.java
@@ -1,0 +1,48 @@
+package io.github.alloffabric.artis.event;
+
+import io.github.alloffabric.artis.Artis;
+import io.github.alloffabric.artis.api.ArtisExistingBlockType;
+import io.github.alloffabric.artis.api.ArtisExistingItemType;
+import io.github.alloffabric.artis.api.ArtisTableType;
+import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
+import net.fabricmc.fabric.api.event.player.UseBlockCallback;
+import net.fabricmc.fabric.api.event.player.UseItemCallback;
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.TypedActionResult;
+import net.minecraft.util.registry.Registry;
+
+public class ArtisEvents {
+    public static void init() {
+        UseBlockCallback.EVENT.register((playerEntity, world, hand, blockHitResult) -> {
+            Block block = world.getBlockState(blockHitResult.getBlockPos()).getBlock();
+            Identifier identifier = Registry.BLOCK.getId(block);
+            if (Artis.ARTIS_TABLE_TYPES.hasId(identifier)) {
+                ArtisTableType type = Artis.ARTIS_TABLE_TYPES.get(identifier);
+                if (type instanceof ArtisExistingBlockType) {
+                    if (!world.isClient) ContainerProviderRegistry.INSTANCE.openContainer(identifier, playerEntity, buf -> buf.writeBlockPos(blockHitResult.getBlockPos()));
+                    return ActionResult.SUCCESS;
+                }
+            }
+            return ActionResult.PASS;
+        });
+
+        UseItemCallback.EVENT.register((playerEntity, world, hand) -> {
+            if (!playerEntity.getStackInHand(hand).isEmpty()) {
+                Item item = playerEntity.getStackInHand(hand).getItem();
+                Identifier identifier = Registry.ITEM.getId(item);
+                if (Artis.ARTIS_TABLE_TYPES.hasId(identifier)) {
+                    ArtisTableType type = Artis.ARTIS_TABLE_TYPES.get(identifier);
+                    if (type instanceof ArtisExistingItemType) {
+                        if (!world.isClient)
+                            ContainerProviderRegistry.INSTANCE.openContainer(identifier, playerEntity, buf -> buf.writeBlockPos(playerEntity.getBlockPos()));
+                        return TypedActionResult.success(playerEntity.getStackInHand(hand));
+                    }
+                }
+            }
+            return TypedActionResult.pass(playerEntity.getStackInHand(hand));
+        });
+    }
+}

--- a/src/main/java/io/github/alloffabric/artis/inventory/ArtisCraftingInventory.java
+++ b/src/main/java/io/github/alloffabric/artis/inventory/ArtisCraftingInventory.java
@@ -6,8 +6,12 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.inventory.Inventories;
 import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.CraftingRecipe;
 import net.minecraft.recipe.RecipeFinder;
+import net.minecraft.recipe.RecipeType;
 import net.minecraft.util.DefaultedList;
+
+import java.util.Optional;
 
 public class ArtisCraftingInventory extends CraftingInventory {
 	private final DefaultedList<ItemStack> stacks;
@@ -74,9 +78,20 @@ public class ArtisCraftingInventory extends CraftingInventory {
 		return getInvStack(getWidth() * getHeight());
 	}
 
-	public ArtisTableType getType() {
-		return (container).getTableType();
+	public RecipeType getType() {
+        Optional<CraftingRecipe> opt = getPlayer().getEntityWorld().getRecipeManager().getFirstMatch(container.getTableType(), container.getCraftInv(), getPlayer().getEntityWorld());
+        Optional<CraftingRecipe> optCrafting = getPlayer().getEntityWorld().getRecipeManager().getFirstMatch(RecipeType.CRAFTING, container.getCraftInv(), getPlayer().getEntityWorld());
+	    if (opt.isPresent()) {
+            return (container).getTableType();
+        } else if (optCrafting.isPresent()) {
+            return RecipeType.CRAFTING;
+        }
+	    return (container).getTableType();
 	}
+
+	public boolean shouldCompareCatalyst() {
+	    return container.getTableType().hasCatalystSlot();
+    }
 
 	public PlayerEntity getPlayer() {
 		return container.getPlayer();

--- a/src/main/java/io/github/alloffabric/artis/inventory/ArtisNormalCraftingController.java
+++ b/src/main/java/io/github/alloffabric/artis/inventory/ArtisNormalCraftingController.java
@@ -1,0 +1,41 @@
+package io.github.alloffabric.artis.inventory;
+
+import io.github.alloffabric.artis.Artis;
+import io.github.alloffabric.artis.ArtisClient;
+import io.github.alloffabric.artis.api.ArtisCraftingRecipe;
+import io.github.alloffabric.artis.api.ArtisTableType;
+import io.github.cottonmc.cotton.gui.CottonCraftingController;
+import io.github.cottonmc.cotton.gui.client.BackgroundPainter;
+import io.github.cottonmc.cotton.gui.client.ScreenDrawing;
+import io.github.cottonmc.cotton.gui.widget.*;
+import io.github.cottonmc.cotton.gui.widget.data.Alignment;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.packet.ContainerSlotUpdateS2CPacket;
+import net.minecraft.container.BlockContext;
+import net.minecraft.container.Slot;
+import net.minecraft.container.SlotActionType;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.CraftingInventory;
+import net.minecraft.inventory.CraftingResultInventory;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.CraftingRecipe;
+import net.minecraft.recipe.Recipe;
+import net.minecraft.recipe.RecipeFinder;
+import net.minecraft.recipe.RecipeType;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.LiteralText;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.World;
+
+import java.util.Optional;
+
+/*
+ * A special type of the ArtisCraftingController used for tables with support for vanilla crafting.
+ */
+public class ArtisNormalCraftingController extends ArtisCraftingController {
+	public ArtisNormalCraftingController(ArtisTableType type, int syncId, PlayerEntity player, BlockContext context) {
+		super(type, syncId, player, context);
+	}
+}

--- a/src/main/java/io/github/alloffabric/artis/inventory/ValidatedArtisResultSlot.java
+++ b/src/main/java/io/github/alloffabric/artis/inventory/ValidatedArtisResultSlot.java
@@ -1,5 +1,6 @@
 package io.github.alloffabric.artis.inventory;
 
+import io.github.alloffabric.artis.Artis;
 import io.github.alloffabric.artis.api.ArtisCraftingRecipe;
 import io.github.alloffabric.artis.api.SpecialCatalyst;
 import io.github.cottonmc.cotton.gui.ValidatedSlot;

--- a/src/main/java/io/github/alloffabric/artis/recipe/ShapedArtisRecipe.java
+++ b/src/main/java/io/github/alloffabric/artis/recipe/ShapedArtisRecipe.java
@@ -37,14 +37,16 @@ public class ShapedArtisRecipe extends ShapedRecipe implements ArtisCraftingReci
 		if (!(inventory instanceof ArtisCraftingInventory)) return false;
 		ArtisCraftingInventory artis = (ArtisCraftingInventory)inventory;
 		ItemStack toTest = artis.getCatalyst();
-		if (!catalyst.test(toTest)) return false;
-		if (toTest.isDamageable()) {
-			if (toTest.getMaxDamage() - toTest.getDamage() < catalystCost) return false;
-		} else if (toTest.getItem() instanceof SpecialCatalyst) {
-			if (!((SpecialCatalyst) toTest.getItem()).matches(toTest, catalystCost)) return false;
-		} else {
-			if (toTest.getCount() < catalystCost) return false;
-		}
+		if (artis.shouldCompareCatalyst()) {
+            if (!catalyst.test(toTest)) return false;
+            if (toTest.isDamageable()) {
+                if (toTest.getMaxDamage() - toTest.getDamage() < catalystCost) return false;
+            } else if (toTest.getItem() instanceof SpecialCatalyst) {
+                if (!((SpecialCatalyst) toTest.getItem()).matches(toTest, catalystCost)) return false;
+            } else {
+                if (toTest.getCount() < catalystCost) return false;
+            }
+        }
 
 		for(int i = 0; i <= artis.getWidth() - this.getWidth(); ++i) {
 			for(int j = 0; j <= artis.getHeight() - this.getHeight(); ++j) {
@@ -85,9 +87,9 @@ public class ShapedArtisRecipe extends ShapedRecipe implements ArtisCraftingReci
 
 	@Override
 	public ItemStack craft(CraftingInventory inv) {
-//		if (FabricLoader.getInstance().isModLoaded("nbtcrafting")) {
-//			return NbtCraftingUtil.getOutputStack(getOutput(), getPreviewInputs(), inv);
-//		}
+		if (FabricLoader.getInstance().isModLoaded("nbtcrafting")) {
+			return NbtCraftingUtil.getOutputStack(getOutput(), getPreviewInputs(), inv);
+		}
 		return this.getOutput().copy();
 	}
 

--- a/src/main/java/io/github/alloffabric/artis/recipe/ShapedArtisSerializer.java
+++ b/src/main/java/io/github/alloffabric/artis/recipe/ShapedArtisSerializer.java
@@ -35,8 +35,8 @@ public class ShapedArtisSerializer implements RecipeSerializer<ShapedArtisRecipe
 		int height = pattern.length;
 		DefaultedList<Ingredient> ingredients = getIngredients(pattern, key, width, height);
 		ItemStack output = ShapedRecipe.getItemStack(JsonHelper.getObject(jsonObject, "result"));
-		Ingredient catalyst = Ingredient.fromJson(jsonObject.get("catalyst"));
-		int cost = JsonHelper.getInt(jsonObject, "cost");
+		Ingredient catalyst = JsonHelper.hasElement(jsonObject,"catalyst") ? Ingredient.fromJson(jsonObject.get("catalyst")) : Ingredient.ofStacks(ItemStack.EMPTY);
+        int cost = JsonHelper.hasElement(jsonObject, "cost") ? JsonHelper.getInt(jsonObject, "cost") : 0;
 		return new ShapedArtisRecipe(type, this, id, group, width, height, ingredients, output, catalyst, cost);
 	}
 

--- a/src/main/java/io/github/alloffabric/artis/recipe/ShapelessArtisRecipe.java
+++ b/src/main/java/io/github/alloffabric/artis/recipe/ShapelessArtisRecipe.java
@@ -40,22 +40,24 @@ public class ShapelessArtisRecipe extends ShapelessRecipe implements ArtisCrafti
 		if (!(inventory instanceof ArtisCraftingInventory)) return false;
 		ArtisCraftingInventory artis = (ArtisCraftingInventory)inventory;
 		ItemStack toTest = artis.getCatalyst();
-		if (!catalyst.test(toTest)) return false;
-		if (toTest.isDamageable()) {
-			if (toTest.getMaxDamage() - toTest.getDamage() < catalystCost) return false;
-		} else if (toTest.getItem() instanceof SpecialCatalyst) {
-			if (!((SpecialCatalyst) toTest.getItem()).matches(toTest, catalystCost)) return false;
-		} else {
-			if (toTest.getCount() < catalystCost) return false;
-		}
+		if (artis.shouldCompareCatalyst()) {
+            if (!catalyst.test(toTest)) return false;
+            if (toTest.isDamageable()) {
+                if (toTest.getMaxDamage() - toTest.getDamage() < catalystCost) return false;
+            } else if (toTest.getItem() instanceof SpecialCatalyst) {
+                if (!((SpecialCatalyst) toTest.getItem()).matches(toTest, catalystCost)) return false;
+            } else {
+                if (toTest.getCount() < catalystCost) return false;
+            }
+        }
 		return super.matches(inventory, world);
 	}
 
 	@Override
 	public ItemStack craft(CraftingInventory inv) {
-//		if (FabricLoader.getInstance().isModLoaded("nbtcrafting")) {
-//			return NbtCraftingUtil.getOutputStack(getOutput(), getPreviewInputs(), inv);
-//		}
+		if (FabricLoader.getInstance().isModLoaded("nbtcrafting")) {
+			return NbtCraftingUtil.getOutputStack(getOutput(), getPreviewInputs(), inv);
+		}
 		return this.getOutput().copy();
 	}
 

--- a/src/main/java/io/github/alloffabric/artis/recipe/ShapelessArtisSerializer.java
+++ b/src/main/java/io/github/alloffabric/artis/recipe/ShapelessArtisSerializer.java
@@ -28,8 +28,8 @@ public class ShapelessArtisSerializer implements RecipeSerializer<ShapelessArtis
 			throw new JsonParseException("Too many ingredients for shapeless " + type.getId().toString() + " recipe");
 		} else {
 			ItemStack output = ShapedRecipe.getItemStack(JsonHelper.getObject(jsonObject, "result"));
-			Ingredient catalyst = Ingredient.fromJson(jsonObject.get("catalyst"));
-			int cost = JsonHelper.getInt(jsonObject, "cost");
+            Ingredient catalyst = JsonHelper.hasElement(jsonObject,"catalyst") ? Ingredient.fromJson(jsonObject.get("catalyst")) : Ingredient.ofStacks(ItemStack.EMPTY);
+			int cost = JsonHelper.hasElement(jsonObject, "cost") ? JsonHelper.getInt(jsonObject, "cost") : 0;
 			return new ShapelessArtisRecipe(type, this, id, group, ingredients, output, catalyst, cost);
 		}
 	}


### PR DESCRIPTION
This PR adds quite a few features as well as some well-needed bug fixes.

- Allow defining existing blocks and items as Artis tables (#10) 
- Allow enabling vanilla recipes in Artis tables (disabled by default)
- Allow enabling/disabling the catalyst slot in Artis tables (disabled by default) (#11)
- Re-enable NBT Crafting support (and update it)
- Update Artifice
- Fix Artis table guis being invisible when no color is specified
- Fix recipes not working when the catalyst or cost section are removed

Additionally, once this is merged I will update the wiki with the new information.