### PR TITLE
fix shiftclicking craft bug

### DIFF
--- a/src/main/java/io/github/alloffabric/artis/Artis.java
+++ b/src/main/java/io/github/alloffabric/artis/Artis.java
@@ -36,6 +36,9 @@ import java.util.function.Supplier;
 public class Artis implements ModInitializer {
     public static final String MODID = "artis";
 
+    public static final Identifier recipe_sync = new Identifier(MODID,"sync_recipe");
+    public static final Identifier dummy = new Identifier("null","null");
+
     public static final Logger logger = LogManager.getLogger();
 
     public static final ArrayList<ArtisTableBlock> ARTIS_TABLE_BLOCKS = new ArrayList<>();

--- a/src/main/java/io/github/alloffabric/artis/ArtisClient.java
+++ b/src/main/java/io/github/alloffabric/artis/ArtisClient.java
@@ -96,7 +96,6 @@ public class ArtisClient implements ClientModInitializer {
                         }
                     });
                 });
-
     }
 
     public static void updateLastRecipe(ArtisCraftingController container, Recipe<CraftingInventory> rec) {

--- a/src/main/java/io/github/alloffabric/artis/inventory/ArtisCraftingInventory.java
+++ b/src/main/java/io/github/alloffabric/artis/inventory/ArtisCraftingInventory.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 public class ArtisCraftingInventory extends CraftingInventory {
     private final DefaultedList<ItemStack> stacks;
     private final ArtisCraftingController container;
-    private boolean checkMatrixChanges = true;
+    private boolean checkMatrixChanges = false;
 
     public ArtisCraftingInventory(ArtisCraftingController container, int width, int height) {
         super(container, width, height);
@@ -97,5 +97,9 @@ public class ArtisCraftingInventory extends CraftingInventory {
 
     public void setCheckMatrixChanges(boolean b) {
         this.checkMatrixChanges = b;
+    }
+
+    public DefaultedList<ItemStack> getStacks() {
+        return stacks;
     }
 }

--- a/src/main/java/io/github/alloffabric/artis/inventory/ArtisCraftingInventory.java
+++ b/src/main/java/io/github/alloffabric/artis/inventory/ArtisCraftingInventory.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 public class ArtisCraftingInventory extends CraftingInventory {
     private final DefaultedList<ItemStack> stacks;
     private final ArtisCraftingController container;
+    private boolean checkMatrixChanges = true;
 
     public ArtisCraftingInventory(ArtisCraftingController container, int width, int height) {
         super(container, width, height);
@@ -48,16 +49,15 @@ public class ArtisCraftingInventory extends CraftingInventory {
     public ItemStack removeStack(int slot, int amount) {
         ItemStack stack = Inventories.splitStack(this.stacks, slot, amount);
         if (!stack.isEmpty()) {
-            this.container.onContentChanged(this);
+            if (checkMatrixChanges)this.container.onContentChanged(this);
         }
-
         return stack;
     }
 
     @Override
     public void setStack(int slot, ItemStack stack) {
         this.stacks.set(slot, stack);
-        this.container.onContentChanged(this);
+        if (checkMatrixChanges)this.container.onContentChanged(this);
     }
 
     @Override
@@ -93,5 +93,9 @@ public class ArtisCraftingInventory extends CraftingInventory {
 
     public PlayerEntity getPlayer() {
         return container.getPlayer();
+    }
+
+    public void setCheckMatrixChanges(boolean b) {
+        this.checkMatrixChanges = b;
     }
 }


### PR DESCRIPTION
This not only fixes shiftcrafting not working correctly, but also caches the last recipe similar to fastworkbench so repeated shift crafts don't stall the server.